### PR TITLE
Fix pdf download perms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,17 +49,17 @@ jours tout en conservant l'historique.
 
 ## Permissions
 
-| Profil                      | Fiche + registre | Contrôle routier | Bordereau | Cartographie | Obesrvatoires | 🆕 Cartographie des exutoires | Accès admin |
-|-----------------------------|------------------|------------------|-----------|--------------|---------------|-------------------------------|-------------|
-| **Staff Track déchets**     | ✅                | ✅                | ✅         | ✅            | ✅             | ✅                             | ✅           |
-| **Administration centrale** | ✅                | ✅                | ✅         | ✅            | ✅             | ✅                             | ❌           |
-| **Inspecteur ICPE**         | ✅                | ✅                | ✅         | ✅            | ❌             | ✅                             | ❌           |
-| **CTT**                     | ✅                | ✅                | ✅         | ✅            | ❌             | ❌                             | ❌           |
-| **Inspection du travail**   | ✅                | ❌                | ✅         | ✅            | ❌             | ❌                             | ❌           |
-| **Gendarmerie**             | ✅                | ✅                | ✅         | ✅            | ❌             | ✅                             | ❌           |
-| **ARS**                     | ✅                | ❌                | ✅         | ✅            | ❌             | ❌                             | ❌           |
-| **Douanes**                 | ✅                | ✅                | ✅         | ✅            | ❌             | ❌                             | ❌           |
-| **Observatoires**           | ❌                | ❌                | ❌         | ✅            | ✅             | ❌                             | ❌           |
+| Profil                      | Fiche + registre | Contrôle routier | Bordereau | Cartographie | Observatoires | 🆕 Cartographie des exutoires | Accès admin |
+|-----------------------------|------------------|------------------|-----------|--------------|--------------|-------------------------------|-------------|
+| **Staff Track déchets**     | ✅                | ✅                | ✅         | ✅            | ✅            | ✅                             | ✅           |
+| **Administration centrale** | ✅                | ✅                | ✅         | ✅            | ✅            | ✅                             | ❌           |
+| **Inspecteur ICPE**         | ✅                | ✅                | ✅         | ✅            | ❌            | ✅                             | ❌           |
+| **CTT**                     | ✅                | ✅                | ✅         | ✅            | ❌            | ❌                             | ❌           |
+| **Inspection du travail**   | ✅                | ❌                | ✅         | ✅            | ❌            | ❌                             | ❌           |
+| **Gendarmerie**             | ✅                | ✅                | ✅         | ✅            | ✅            | ✅                             | ❌           |
+| **ARS**                     | ✅                | ❌                | ✅         | ✅            | ❌            | ❌                             | ❌           |
+| **Douanes**                 | ✅                | ✅                | ✅         | ✅            | ❌            | ❌                             | ❌           |
+| **Observatoires**           | ❌                | ❌                | ❌         | ✅            | ✅            | ❌                             | ❌           |
 
 ## Bannière configurable
 

--- a/src/accounts/constants.py
+++ b/src/accounts/constants.py
@@ -44,7 +44,16 @@ PERMS_ROAD_CONTROL = [
     UserCategoryChoice.GENDARMERIE,
     UserCategoryChoice.DOUANE,
 ]
-PERMS_BSD = PERMS_SHEET_AND_REGISTRY
+PERMS_BSD_SEARCH = [
+    UserCategoryChoice.STAFF_TD,
+    UserCategoryChoice.ADMINISTRATION_CENTRALE,
+    UserCategoryChoice.INSPECTEUR_ICPE,
+    UserCategoryChoice.CTT,
+    UserCategoryChoice.GENDARMERIE,
+    UserCategoryChoice.DOUANE,
+    UserCategoryChoice.INSPECTION_TRAVAIL,
+    UserCategoryChoice.ARS,
+]
 PERMS_MAP = [
     UserCategoryChoice.STAFF_TD,
     UserCategoryChoice.ADMINISTRATION_CENTRALE,

--- a/src/accounts/menus.py
+++ b/src/accounts/menus.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from simple_menu import Menu, MenuItem
 
 from accounts.constants import (
-    PERMS_BSD,
+    PERMS_BSD_SEARCH,
     PERMS_DATA_EXPORT,
     PERMS_MAP,
     PERMS_MAP_ICPE,
@@ -45,7 +45,7 @@ Menu.add_item("main", PermsItem("Contrôle routier", reverse("roadcontrol"), all
 
 Menu.add_item(
     "main",
-    PermsItem("Bordereau", reverse("roadcontrol_bsd_search"), allowed_categories=PERMS_BSD),
+    PermsItem("Bordereau", reverse("roadcontrol_bsd_search"), allowed_categories=PERMS_BSD_SEARCH),
 )
 
 Menu.add_item(

--- a/src/common/mixins.py
+++ b/src/common/mixins.py
@@ -78,6 +78,7 @@ class FullyLoggedMixin(AccessMixin):
             return True
 
         user_category = self.request.user.user_category
+        # breakpoint()
         return user_category in categories
 
     def dispatch(self, request, *args, **kwargs):
@@ -86,7 +87,7 @@ class FullyLoggedMixin(AccessMixin):
 
         if not user_test_result:
             return self.handle_no_permission(request)
-
+        # breakpoint()
         in_category = self.check_has_right_categories(self.get_allowed_user_categories())
         if not in_category:
             raise PermissionDenied()

--- a/src/roadcontrol/tests/test_views.py
+++ b/src/roadcontrol/tests/test_views.py
@@ -189,3 +189,39 @@ def test_roadcontrol_bsd_search_result(verified_user):
     url = reverse("roadcontrol_bsd_search_result")
     res = verified_user.get(url)
     assert res.status_code == 200
+
+
+def test_single_bsd_pdf_download_anon(anon_client):
+    url = reverse("single_bsd_pdf_download")
+    res = anon_client.get(url)
+    assert res.status_code == 302
+
+
+@pytest.mark.parametrize(
+    "get_profile",
+    [
+        "verified_icpe",
+        "verified_ctt",
+        "verified_inspection_travail",
+        "verified_gendarme",
+        "verified_ars",
+        "verified_douane",
+        "verified_adm_centrale",
+    ],
+    indirect=True,
+)
+def test_single_bsd_pdf_download_is_allowed(get_profile):
+    url = reverse("single_bsd_pdf_download")
+    res = get_profile.get(url)
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "get_profile",
+    ["verified_observatoire"],
+    indirect=True,
+)
+def test_single_bsd_pdf_download_is_denied(get_profile):
+    url = reverse("single_bsd_pdf_download")
+    res = get_profile.get(url)
+    assert res.status_code == 403

--- a/src/roadcontrol/urls.py
+++ b/src/roadcontrol/urls.py
@@ -7,18 +7,18 @@ from .views import (
     BundleProcessingView,
     FragmentBundleProcessingView,
     NoResultRoadControlPdf,
-    RoadControlPdf,
     RoadControlPdfBundle,
     RoadControlPdfBundleResult,
     RoadControlRecentPdfs,
     RoadControlSearch,
     RoadControlSearchResult,
+    SingleBsdPdfDownload,
 )
 
 urlpatterns = [
     path("", RoadControlSearch.as_view(), name="roadcontrol"),
     path("search-result/", RoadControlSearchResult.as_view(), name="roadcontrol_search_result"),
-    path("pdf/", RoadControlPdf.as_view(), name="roadcontrol_pdf"),
+    path("pdf/", SingleBsdPdfDownload.as_view(), name="single_bsd_pdf_download"),
     path("no-result-pdf/", NoResultRoadControlPdf.as_view(), name="no_result_roadcontrol_pdf"),
     path("pdf-bundle-process/", RoadControlPdfBundle.as_view(), name="roadcontrol_pdf_bundle"),
     path(

--- a/src/roadcontrol/views.py
+++ b/src/roadcontrol/views.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.views.generic import DetailView, FormView, TemplateView
 
-from accounts.constants import PERMS_BSD, PERMS_ROAD_CONTROL
+from accounts.constants import PERMS_BSD_SEARCH, PERMS_ROAD_CONTROL
 from common.constants import STATE_DONE, STATE_RUNNING
 from common.mixins import FullyLoggedMixin
 from config.celery_app import app
@@ -136,9 +136,11 @@ class NoResultRoadControlPdf(FullyLoggedMixin, BsdRetrievingMixin, FormView):
         return response
 
 
-class RoadControlPdf(FullyLoggedMixin, BsdRetrievingMixin, TemplateView):
+class SingleBsdPdfDownload(FullyLoggedMixin, BsdRetrievingMixin, TemplateView):
+    """Pdf download view used by control and bsd views"""
+
     template_name = "roadcontrol/road_control_pdf.html"
-    allowed_user_categories = PERMS_ROAD_CONTROL
+    allowed_user_categories = list({*PERMS_ROAD_CONTROL, *PERMS_BSD_SEARCH})
 
     def get_pdf_download_link(self, bsd_type, bsd_id):
         link = query_td_pdf(bsd_type=bsd_type, bsd_id=bsd_id)
@@ -315,7 +317,7 @@ class RoadControlRecentPdfs(FullyLoggedMixin, TemplateView):
 
 class BsdSearch(FullyLoggedMixin, TemplateView):
     template_name = "roadcontrol/bsd_search.html"
-    allowed_user_categories = PERMS_BSD
+    allowed_user_categories = PERMS_BSD_SEARCH
 
     def get_context_data(self, **kwargs):
         form = BsdSearchForm()
@@ -326,7 +328,7 @@ class BsdSearchResult(FullyLoggedMixin, FormView):
     form_class = BsdSearchForm
     success_url = ""
     template_name = "roadcontrol/partials/search_result.html"
-    allowed_user_categories = PERMS_BSD
+    allowed_user_categories = PERMS_BSD_SEARCH
 
     def form_valid(self, form):
         bsd_id = form.cleaned_data["bsd_id"]
@@ -375,7 +377,7 @@ class BsdSearchResult(FullyLoggedMixin, FormView):
 
 class BsdRecentPdfs(FullyLoggedMixin, TemplateView):
     template_name = "roadcontrol/partials/_recent_pdfs.html"
-    allowed_user_categories = PERMS_BSD
+    allowed_user_categories = PERMS_BSD_SEARCH
 
     def get_recent_downloads(self):
         user = self.request.user

--- a/src/templates/roadcontrol/partials/_bsd_card.html
+++ b/src/templates/roadcontrol/partials/_bsd_card.html
@@ -49,7 +49,7 @@
                 </div>
             </div>
             <div class="bsd-card__content__cta">
-                <form hx-post="{% url "roadcontrol_pdf" %}"
+                <form hx-post="{% url "single_bsd_pdf_download" %}"
                       hx-indicator="#id_bsd_spinner-{{ bsd.id }}">
                     {% csrf_token %}
                     <input type="hidden" value="{{ bsd.id }}" name="bsd_id" />


### PR DESCRIPTION
Corrige les permissins d'accès pour l'inspection du travail au niveau du téléchargement de bsd.

La pr corrige un bug sur la liste des permissions de la vue de download, et renomme certaines variables et vues pour les rendre plus explicites.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16766)
