### PR TITLE
Mise à jour des requpetes carto pour sélectionner sur le nouveau schéma refined_zone_vigiedechets

### DIFF
--- a/src/maps/data/queries.py
+++ b/src/maps/data/queries.py
@@ -13,33 +13,33 @@ select
     code_postal,
     commune
 from 
-    refined_zone_stats_publiques.installations_icpe_2024
+    refined_zone_vigiedechets.installations_icpe_2024
 """
 
 icpe_installations_waste_processed_sql = """
 select
     *
 from
-    refined_zone_stats_publiques.icpe_installations_daily_processed_waste
+    refined_zone_vigiedechets.icpe_installations_daily_processed_waste
 """
 
 icpe_departements_waste_processed_sql = """
 select
     *
 from
-    refined_zone_stats_publiques.icpe_departements_daily_processed_waste
+    refined_zone_vigiedechets.icpe_departements_daily_processed_waste
 """
 
 icpe_regions_waste_processed_sql = """
 select
     *
 from
-    refined_zone_stats_publiques.icpe_regions_daily_processed_waste
+    refined_zone_vigiedechets.icpe_regions_daily_processed_waste
 """
 
 icpe_france_waste_processed_sql = """
 select
     *
 from
-    refined_zone_stats_publiques.icpe_france_daily_processed_waste
+    refined_zone_vigiedechets.icpe_france_daily_processed_waste
 """

--- a/src/maps/management/commands/retrieve_companies.py
+++ b/src/maps/management/commands/retrieve_companies.py
@@ -73,7 +73,7 @@ SELECT
 
     coords
 FROM
-    refined_zone_analytics.cartographie_des_etablissements_geocoded
+    refined_zone_vigiedechets.cartographie_des_etablissements_geocoded
 ORDER BY siret
 """
 BATCH_SIZE = 10000
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         self.stdout.write("Deleting existing CartoCompany objects...")
         CartoCompany.objects.all().delete()
 
-        count_query = "SELECT COUNT() FROM refined_zone_analytics.cartographie_des_etablissements_geocoded"
+        count_query = "SELECT COUNT() FROM refined_zone_vigiedechets.cartographie_des_etablissements_geocoded"
 
         count_df = build_query(count_query)
         total_count = count_df.iloc[0, 0]


### PR DESCRIPTION
Pour une meilleur organisation, un nouveau schéma `refined_zone_enriched` a été créé sur l'entrepôt de données.
Cette PR migre les requêtes pour sélectionner sur le nouveau schéma.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16917)
