### PR TITLE
Enlever mention dangereux des sheets comprenant des déchets ND et TEXS

### DIFF
--- a/src/templates/sheets/sheet.html
+++ b/src/templates/sheets/sheet.html
@@ -386,7 +386,7 @@
                         <div class="fr-alert fr-alert--warning">
                             <h3 class="fr-alert__title">Attention : traitements de déchets sans rubriques
                                 correspondantes</h3>
-                            <p>L'établissement a traité des déchets dangereux mais les données ICPE sont manquantes.</p>
+                            <p>L'établissement a traité des déchets mais les données ICPE sont manquantes.</p>
                         </div>
                         {% render_bs_without_icpe_authorization_tables sheet %}
                     </div>
@@ -412,7 +412,7 @@
                     <div class="fr-alert fr-alert--warning">
                         <h3 class="fr-alert__title">Attention : traitements de déchets sans rubriques
                             correspondantes</h3>
-                        <p>L'établissement a traité des déchets dangereux mais les données ICPE sont manquantes.</p>
+                        <p>L'établissement a traité des déchets mais les données ICPE sont manquantes.</p>
                     </div>
                     {% render_bs_without_icpe_authorization_tables sheet %}
                 </div>

--- a/src/templates/sheets/sheetpdf.html
+++ b/src/templates/sheets/sheetpdf.html
@@ -362,7 +362,7 @@
                         <div>
                             <div class="fr-alert fr-alert--warning">
                                 <h3 class="fr-alert__title">Attention : traitements de déchets sans rubriques correspondantes</h3>
-                                <p>L'établissement a traité des déchets dangereux mais les données ICPE sont manquantes.</p>
+                                <p>L'établissement a traité des déchets mais les données ICPE sont manquantes.</p>
                             </div>
                             {% render_bs_without_icpe_authorization_tables sheet graph_context="pdf" %}
                         </div>
@@ -383,7 +383,7 @@
                     <div>
                         <div class="fr-alert fr-alert--warning">
                             <h3 class="fr-alert__title">Attention : traitements de déchets sans rubriques correspondantes</h3>
-                            <p>L'établissement a traité des déchets dangereux mais les données ICPE sont manquantes.</p>
+                            <p>L'établissement a traité des déchets mais les données ICPE sont manquantes.</p>
                         </div>
                         {% render_bs_without_icpe_authorization_tables sheet graph_context="pdf" %}
                     </div>


### PR DESCRIPTION
<!--
Changer le wording car ce composant sert aussi aux déchets non dangereux/texs
il faut enlever la mention "dangereux".
-->

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16823)
